### PR TITLE
fix: handle missing values in to_condition

### DIFF
--- a/meteostat/utils/conversions.py
+++ b/meteostat/utils/conversions.py
@@ -195,8 +195,11 @@ def to_condition(value):
     """
     Convert Meteostat condition code to descriptive string
     """
+    # Handle None and NaN values
+    if value is None or pd.isna(value):
+        return None
 
-    if not value or value < 1 or value > 27:
+    if value < 1 or value > 27:
         return None
 
     return [

--- a/tests/unit/test_conversions.py
+++ b/tests/unit/test_conversions.py
@@ -5,6 +5,7 @@ The code is licensed under the MIT license.
 """
 
 import numpy as np
+import pandas as pd
 from meteostat.utils.conversions import (
     celsius_to_fahrenheit,
     celsius_to_kelvin,
@@ -370,3 +371,18 @@ class TestWeatherConditionConversions:
     def test_to_condition_invalid_negative(self):
         """Test weather condition conversion with negative value"""
         assert to_condition(-1) is None
+
+    def test_to_condition_with_nan(self):
+        """to_condition(NaN) should return None, not raise."""
+        assert to_condition(np.nan) is None
+
+    def test_to_condition_with_pandas_na(self):
+        """to_condition(pd.NA) should return None, not raise."""
+        assert to_condition(pd.NA) is None
+
+    def test_to_condition_applied_to_nullable_series(self):
+        """Applying to_condition to a column with missing values must not raise."""
+        result = pd.Series([1, None, 27], dtype="UInt8").apply(to_condition)
+        assert result[0] == "Clear"
+        assert pd.isna(result[1])
+        assert result[2] == "Storm"


### PR DESCRIPTION
`to_condition()` raises on a missing value, so `TimeSeries.fetch(humanize=True)` fails on any series with a gap in `coco`:

```
>>> pd.Series([1, None, 27], dtype="UInt8").apply(to_condition)
ValueError: cannot convert float NaN to integer
```

With a bare `pd.NA` it is `TypeError: boolean value of NA is ambiguous`, raised by the `not value` in the guard.

`SchemaService.humanize()` applies `to_direction` and `to_condition` on consecutive lines. `to_direction` already has the `value is None or pd.isna(value)` guard; `to_condition` does not. This copies that guard across and splits the range check out of the `not value` chain, so 0 is still rejected.

Tests: `tests/unit/test_conversions.py` gains the NaN / `pd.NA` / nullable-column cases that `TestToDirectionEdgeCases` already has for the sibling function.

Ran locally on Python 3.13 / pandas 3.0.5: `pytest tests/unit` 307 passed, `pytest tests/integration` 87 passed. Reverting only `meteostat/utils/conversions.py` and keeping the new tests gives 3 failures, so they are not vacuous. `ruff check meteostat/ tests/` is clean; `ruff format --check` flags only `meteostat/core/network.py`, which this PR does not touch and which is already flagged on `main`. Provider tests not run, per the contributor instructions.

One thing worth flagging: a shorter alternative — moving `pd.isna(value)` to the front of the existing `if not value or ...` chain — also passes everything. I went with the two-part guard so the function reads the same as `to_direction`, and so the `not value` that actually raises on `pd.NA` is gone rather than merely short-circuited. Happy to switch if you prefer the one-liner.

AI disclosure: drafted with Claude Opus 5 (`claude-opus-5`); I reviewed the change and ran every command reported above.
